### PR TITLE
bugfix

### DIFF
--- a/CRRefresh/CRRefresh/Animators/NormalAnimator/NormalFooterAnimator.swift
+++ b/CRRefresh/CRRefresh/Animators/NormalAnimator/NormalFooterAnimator.swift
@@ -88,6 +88,8 @@ open class NormalFooterAnimator: UIView, CRRefreshProtocol {
     
     open func refresh(view: CRRefreshComponent, stateDidChange state: CRRefreshState) {
         switch state {
+        case .idle:
+            titleLabel.text = loadingMoreDescription
         case .refreshing :
             titleLabel.text = loadingDescription
             break

--- a/CRRefresh/CRRefresh/CRRefreshHeaderView.swift
+++ b/CRRefresh/CRRefresh/CRRefreshHeaderView.swift
@@ -66,10 +66,16 @@ open class CRRefreshHeaderView: CRRefreshComponent {
         insets.top          += animator.execute
         insetTDelta          = -animator.execute
         holdInsetTDelta      = -(animator.execute - animator.hold)
-        UIView.animate(withDuration: CRRefreshComponent.animationDuration, animations: { 
+        var point = scrollView.contentOffset;
+        point.y = -insets.top
+        UIView.animate(withDuration: CRRefreshComponent.animationDuration, animations: {
+            
             scrollView.contentOffset.y = self.previousOffsetY
             scrollView.contentInset    = insets
-            scrollView.contentOffset.y = -insets.top
+//            scrollView.contentOffset.y = -insets.top
+            scrollView.setContentOffset(point, animated: false);
+            
+            
         }) { (finished) in
             DispatchQueue.main.async {
                 self.handler?()

--- a/Demo/RefreshController.swift
+++ b/Demo/RefreshController.swift
@@ -78,10 +78,13 @@ class RefreshController: BaseViewController {
             print("开始加载")
             DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: {
                 self?.count += 10
-                self?.tableView.cr.noticeNoMoreData()
+                self?.tableView.cr.endLoadingMore()
                 self?.tableView.reloadData()
             })
         }
+        
+        tableView.isPagingEnabled = true
+        
     }
     
     //MARK: Override


### PR DESCRIPTION
1、修复：footer 在 `resetNoMore` 后 footer文案任然保持 noMoreData，
2、修复：修复#38 开启了pagingEnabled功能，刷新和加载更多将立即回弹问题